### PR TITLE
Fix pkgdoc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ in [ICU](http://icu-project.org/)'s implementation.
 
 ## Documentation and Usage
 
-See [pkgdoc](http://go.pkgdoc.org/github.com/saintfish/chardet)
+See [pkgdoc](https://pkg.go.dev/github.com/saintfish/chardet)


### PR DESCRIPTION
Hello, @saintfish

[The current pkgdoc link](http://go.pkgdoc.org/github.com/saintfish/chardet) has no longer worked because of the link to go.pkgdoc.org, which has moved to pkg.go.dev. So, when users, including you, want to check pkgdoc, they need to search on some browser. It's a bother, I think.

Then, this PR updates the pkgdoc link latest. This change has no side-effect.

I would like you to review this PR.
Thanks in advance.

ref: #4